### PR TITLE
fix: fix various typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__
 .venv2
 .env
 env
+venv
 
 # Test and docs
 .tox

--- a/cachetclient/__init__.py
+++ b/cachetclient/__init__.py
@@ -1,3 +1,3 @@
 from cachetclient.client import Client  # noqa
 
-___version__ = '1.3.0'
+___version__ = '2.0.0'

--- a/cachetclient/base.py
+++ b/cachetclient/base.py
@@ -12,7 +12,7 @@ class Resource:
 
     @property
     def attrs(self) -> dict:
-        """dict: The raw json respons from the server"""
+        """dict: The raw json response from the server"""
         return self._data
 
     def get(self, name) -> Union[int, str, float, bool]:
@@ -147,7 +147,7 @@ class Manager:
 
         Keyword Args:
             page (int): Page to start on
-            per_page (int): Number of entires per page
+            per_page (int): Number of entries per page
 
         Returns:
             Generator of resources
@@ -218,7 +218,7 @@ class Manager:
     def _build_data_dict(self, **kwargs) -> dict:
         """Builds a data dictionary for posting to the server.
 
-        Will ommit key/value pars with None values.
+        Will omit key/value pars with None values.
         This makes partial updates less error prone.
 
         Returns:

--- a/cachetclient/client.py
+++ b/cachetclient/client.py
@@ -15,7 +15,7 @@ def Client(
 
     Args:
         endpoint (str): The api endpoint. for example 'https://status.examples.test/api/v1'.
-                        The endpoint can also be specificed using the ``CACHET_ENDPOINT`` env variable.
+                        The endpoint can also be specified using the ``CACHET_ENDPOINT`` env variable.
         api_token (str): The api token. Can also be specified using ``CACHET_API_TOKEN`` env variable.
         version (str): The api version. If not specified the version will be derived from the
                        endpoint url. The value "1" will create a v1 cachet client.
@@ -27,8 +27,8 @@ def Client(
     if not api_token:
         raise ValueError(
             "No api_token specified. "
-            "The endpoint must be supplied in the Client fuction "
-            "or through the CACHET_API_TOKEN enviroment variable."
+            "The endpoint must be supplied in the Client function "
+            "or through the CACHET_API_TOKEN environment variable."
         )
 
     if not endpoint:
@@ -37,8 +37,8 @@ def Client(
     if not endpoint:
         raise ValueError(
             "No api endpoint specified. "
-            "The token must be supplied in the Client fuction "
-            "or through the CACHET_ENDPOINT enviroment variable."
+            "The token must be supplied in the Client function "
+            "or through the CACHET_ENDPOINT environment variable."
         )
 
     if not version:

--- a/cachetclient/v1/__init__.py
+++ b/cachetclient/v1/__init__.py
@@ -2,7 +2,7 @@ from cachetclient.v1.client import Client  # noqa
 
 from cachetclient.v1.subscribers import Subscriber  # noqa
 from cachetclient.v1.components import Component  # noqa
-from cachetclient.v1.component_groups import CompontentGroup  # noqa
+from cachetclient.v1.component_groups import ComponentGroup  # noqa
 from cachetclient.v1.incident_updates import IndicentUpdate  # noqa
 from cachetclient.v1.metrics import Metrics  # noqa
 from cachetclient.v1.metric_points import MetricPoints  # noqa

--- a/cachetclient/v1/client.py
+++ b/cachetclient/v1/client.py
@@ -1,5 +1,5 @@
 from cachetclient.httpclient import HttpClient
-from cachetclient.v1.component_groups import CompontentGroupManager
+from cachetclient.v1.component_groups import ComponentGroupManager
 from cachetclient.v1.components import ComponentManager
 from cachetclient.v1.incidents import IncidentManager
 from cachetclient.v1.incident_updates import IncidentUpdatesManager
@@ -23,7 +23,7 @@ class Client:
         self.ping = PingManager(self._http)
         self.version = VersionManager(self._http)
         self.components = ComponentManager(self._http)
-        self.component_groups = CompontentGroupManager(self._http, self.components)
+        self.component_groups = ComponentGroupManager(self._http, self.components)
         self.incident_updates = IncidentUpdatesManager(self._http)
         self.incidents = IncidentManager(self._http, self.incident_updates)
         self.metrics = MetricsManager(self._http)

--- a/cachetclient/v1/component_groups.py
+++ b/cachetclient/v1/component_groups.py
@@ -8,7 +8,7 @@ from cachetclient.v1.components import Component, ComponentManager
 from cachetclient.httpclient import HttpClient
 
 
-class CompontentGroup(Resource):
+class ComponentGroup(Resource):
 
     @property
     def id(self) -> int:
@@ -76,7 +76,7 @@ class CompontentGroup(Resource):
 
     @property
     def created_at(self) -> datetime:
-        """datatime: When the group was created"""
+        """datetime: When the group was created"""
         return utils.to_datetime(self.get('created_at'))
 
     @property
@@ -85,15 +85,15 @@ class CompontentGroup(Resource):
         return utils.to_datetime(self.get('updated_at'))
 
 
-class CompontentGroupManager(Manager):
-    resource_class = CompontentGroup
+class ComponentGroupManager(Manager):
+    resource_class = ComponentGroup
     path = 'components/groups'
 
     def __init__(self, http_client: HttpClient, components_manager: ComponentManager):
         super().__init__(http_client)
         self.components = components_manager
 
-    def create(self, *, name: str, order: int = 0, collapsed: int = 0) -> CompontentGroup:
+    def create(self, *, name: str, order: int = 0, collapsed: int = 0) -> ComponentGroup:
         """
         Create a component group
 
@@ -103,19 +103,19 @@ class CompontentGroupManager(Manager):
             collapsed (int): Collapse value (see enums)
 
         Returns:
-            :py:data:`CompoentGroup` instance
+            :py:data:`ComponentGroup` instance
         """
         return self._create(
             self.path,
             {
                 'name': name,
                 'order': order,
-                'collapsed': collapsed,
+                'collapsed': collapsed
             }
         )
 
     def update(self, group_id: int, *, name: str, order: int = None,
-               collapsed: int = None, **kwargs) -> CompontentGroup:
+               collapsed: int = None, **kwargs) -> ComponentGroup:
         """
         Update component group
 
@@ -133,7 +133,7 @@ class CompontentGroupManager(Manager):
             self._build_data_dict(
                 name=name,
                 order=order,
-                collapsed=collapsed,
+                collapsed=collapsed
             ),
         )
 
@@ -146,20 +146,20 @@ class CompontentGroupManager(Manager):
         """
         return self._count(self.path)
 
-    def list(self, page: int = 1, per_page: int = 20) -> Generator[CompontentGroup, None, None]:
+    def list(self, page: int = 1, per_page: int = 20) -> Generator[ComponentGroup, None, None]:
         """
         List all component groups
 
         Keyword Args:
             page (int): The page to start listing
-            per_page: Number of entires per page
+            per_page: Number of entries per page
 
         Returns:
             Generator of :py:data:`ComponentGroup` instances
         """
         yield from self._list_paginated(self.path, page=page, per_page=per_page)
 
-    def get(self, group_id) -> CompontentGroup:
+    def get(self, group_id) -> ComponentGroup:
         """
         Get a component group by id
 

--- a/cachetclient/v1/components.py
+++ b/cachetclient/v1/components.py
@@ -240,7 +240,7 @@ class ComponentManager(Manager):
 
         Keyword Args:
             page (int): The page to start listing
-            per_page (int): Number of entires per page
+            per_page (int): Number of entries per page
 
         Returns:
             Generator of Component instances
@@ -268,7 +268,7 @@ class ComponentManager(Manager):
             component_id (int): Id of the component
 
         Raises:
-            HTTPError: if compontent do not exist
+            HTTPError: if component do not exist
         """
         self._delete(self.path, component_id)
 

--- a/cachetclient/v1/enums.py
+++ b/cachetclient/v1/enums.py
@@ -21,7 +21,7 @@ COMPONENT_STATUS_LIST = [
     COMPONENT_STATUS_MAJOR_OUTAGE
 ]
 
-# Componet group collapse value
+# Component group collapse value
 #: [0] No
 COMPONENT_GROUP_COLLAPSED_FALSE = 0
 #: [1] Yes

--- a/cachetclient/v1/incident_updates.py
+++ b/cachetclient/v1/incident_updates.py
@@ -151,7 +151,7 @@ class IncidentUpdatesManager(Manager):
 
         Keyword Args:
             page (int): The first page to request
-            per_page (int): Entires per page
+            per_page (int): Entries per page
 
         Return:
             Generator of :py:data:`IncidentUpdate`s

--- a/cachetclient/v1/incidents.py
+++ b/cachetclient/v1/incidents.py
@@ -66,7 +66,7 @@ class Incident(Resource):
 
     @property
     def visible(self) -> int:
-        """bool: Get or set visibility of the indcinent"""
+        """bool: Get or set visibility of the incident"""
         return self.get('visible') == 1
 
     @visible.setter
@@ -219,7 +219,7 @@ class IncidentManager(Manager):
 
         Keyword Args:
             page (int): Page to start on
-            per_page (int): Entires per page
+            per_page (int): entries per page
 
         Returns:
             Generator of :py:data:`Incident`s

--- a/cachetclient/v1/ping.py
+++ b/cachetclient/v1/ping.py
@@ -10,7 +10,7 @@ class PingManager(Manager):
 
     def __call__(self) -> bool:
         """
-        Shotcut for the :py:data:`get` method.
+        Shortcut for the :py:data:`get` method.
 
         Example::
 
@@ -39,5 +39,3 @@ class PingManager(Manager):
         except Exception as ex:
             logger.warning("Ping: %s", ex)
             return False
-
-        return True

--- a/cachetclient/v1/schedules.py
+++ b/cachetclient/v1/schedules.py
@@ -32,13 +32,13 @@ class ScheduleManager(Manager):
     resource_class = Schedule
 
     def create(self, *args, **kwargs):
-        raise NotImplementedError("Create schedule not implementd")
+        raise NotImplementedError("Create schedule not implemented")
 
     def update(self, *args, **kwargs):
         raise NotImplementedError("update schedule not implemented")
 
     def list(self, *args, **kwargs):
-        raise NotImplementedError("List scedules not implemented")
+        raise NotImplementedError("List schedules not implemented")
 
     def delete(self, schedule_id):
         raise NotImplementedError("Delete schedules not implemented")

--- a/cachetclient/v1/subscribers.py
+++ b/cachetclient/v1/subscribers.py
@@ -78,7 +78,7 @@ class SubscriberManager(Manager):
 
         Keyword Args:
             page (int): The page to start listing
-            per_page: Number of entires per page
+            per_page: Number of entries per page
 
         Returns:
             Generator of Subscriber instances

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ copyright = '2019, Zetta.IO Technology'
 author = 'Einar Forselv'
 
 # The full version, including alpha/beta/rc tags
-version = '1.3.0'
+version = '2.0.0'
 release = version
 
 # The master toctree document.

--- a/docs/reference/cachetclient.v1.component_groups.rst
+++ b/docs/reference/cachetclient.v1.component_groups.rst
@@ -10,33 +10,33 @@ Resource
 Methods
 *******
 
-.. automethod:: CompontentGroup.update
-.. automethod:: CompontentGroup.delete
+.. automethod:: ComponentGroup.update
+.. automethod:: ComponentGroup.delete
 
 Attributes
 **********
 
-.. autoattribute:: CompontentGroup.id
-.. autoattribute:: CompontentGroup.name
-.. autoattribute:: CompontentGroup.enabled_components
-.. autoattribute:: CompontentGroup.order
-.. autoattribute:: CompontentGroup.collapsed
-.. autoattribute:: CompontentGroup.lowest_human_status
-.. autoattribute:: CompontentGroup.is_collapsed
-.. autoattribute:: CompontentGroup.is_open
-.. autoattribute:: CompontentGroup.is_operational
-.. autoattribute:: CompontentGroup.created_at
-.. autoattribute:: CompontentGroup.updated_at
+.. autoattribute:: ComponentGroup.id
+.. autoattribute:: ComponentGroup.name
+.. autoattribute:: ComponentGroup.enabled_components
+.. autoattribute:: ComponentGroup.order
+.. autoattribute:: ComponentGroup.collapsed
+.. autoattribute:: ComponentGroup.lowest_human_status
+.. autoattribute:: ComponentGroup.is_collapsed
+.. autoattribute:: ComponentGroup.is_open
+.. autoattribute:: ComponentGroup.is_operational
+.. autoattribute:: ComponentGroup.created_at
+.. autoattribute:: ComponentGroup.updated_at
 
 Manager
 -------
 
-.. automethod:: CompontentGroupManager.create
-.. automethod:: CompontentGroupManager.update
-.. automethod:: CompontentGroupManager.count
-.. automethod:: CompontentGroupManager.list
-.. automethod:: CompontentGroupManager.get
-.. automethod:: CompontentGroupManager.delete
-.. automethod:: CompontentGroupManager.instance_from_dict
-.. automethod:: CompontentGroupManager.instance_from_json
-.. automethod:: CompontentGroupManager.instance_list_from_json
+.. automethod:: ComponentGroupManager.create
+.. automethod:: ComponentGroupManager.update
+.. automethod:: ComponentGroupManager.count
+.. automethod:: ComponentGroupManager.list
+.. automethod:: ComponentGroupManager.get
+.. automethod:: ComponentGroupManager.delete
+.. automethod:: ComponentGroupManager.instance_from_dict
+.. automethod:: ComponentGroupManager.instance_from_json
+.. automethod:: ComponentGroupManager.instance_list_from_json

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="cachet-client",
-    version="1.3.0",
+    version="2.0.0",
     description="A python 3 client for the Cachet API",
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
I noticed quite a few typos in the repository, so I've corrected them in this PR. Unfortunately, two of the main classes (`CompontentGroup` and `CompontentGroupManager`) were misspelled, so renaming them to correct the spelling is a breaking change for existing users and hence requires a major version bump. I included the version bump in this PR. 
