### PR TITLE
Add incidents/Incident to __init__.py

### DIFF
--- a/cachetclient/v1/__init__.py
+++ b/cachetclient/v1/__init__.py
@@ -3,6 +3,7 @@ from cachetclient.v1.client import Client  # noqa
 from cachetclient.v1.subscribers import Subscriber  # noqa
 from cachetclient.v1.components import Component  # noqa
 from cachetclient.v1.component_groups import ComponentGroup  # noqa
+from cachetclient.v1.incidents import Incident  # noqa
 from cachetclient.v1.incident_updates import IncidentUpdate  # noqa
 from cachetclient.v1.metrics import Metric  # noqa
 from cachetclient.v1.metric_points import MetricPoint  # noqa


### PR DESCRIPTION
This allows IDE's such as PyCharm to use cachetclient.v1.Incidents.incident as the type for incident objects. Without this line you will get the error, "cannot find reference 'Incidents' in '__init__.py'". 